### PR TITLE
Move widgets above header and fix blue underline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,14 @@
 
 <img align="right" src="./assets/ketting.png?raw=true" height="150" width="150">
 
+[![discord-widget][]][discord-invite]
+[![forge-version][]][forge-commit]
+
 # Ketting
 
 Ketting is a fork of [MinecraftForge](https://github.com/MinecraftForge/MinecraftForge/)
 that enables the use of Bukkit plugins on Forge servers.
-[ ![discord-widget][] ][discord-invite]
-[ ![forge-version][] ][forge-commit]
+
 
 ## Notice
 


### PR DESCRIPTION
This PR moves the widgets for the forge commit and discord server above the header to be more inline with other software repository readmes.

This also fixes the mobile display.

## Desktop (github.com)
![grafik](https://github.com/kettingpowered/Ketting-1-20-x/assets/50475262/cd03c019-9b08-48e9-b68f-25534f07913e)

## Mobile 
![grafik](https://github.com/kettingpowered/Ketting-1-20-x/assets/50475262/28829012-854a-491c-be32-6d0ab8d49580)

![grafik](https://github.com/kettingpowered/Ketting-1-20-x/assets/50475262/e91b98b6-c066-473c-82f9-681a1b6417a5)

