### PR TITLE
Fix ./gradlew setup kettingJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1276,6 +1276,8 @@ project(':forge') {
     // Make sure we run bin compat checking during local testing.
     if (!System.env.MAVEN_USER || !System.env.MAVEN_PASSWORD)
         publish.dependsOn(':forge:checkJarCompatibility')
+
+    tasks.named('compileJava').get().mustRunAfter('extractMapped')
 }
 
 tasks.register('setup') {


### PR DESCRIPTION
Running `./gradlew setup kettingJar` currently results in a build failure because Gradle expects an explicit dependency to be declared between the `extractMapped` and `compileJava` tasks. 