### PR TITLE
Add missing dependencies

### DIFF
--- a/kettinglauncher/src/main/java/org/kettingpowered/ketting/KettingLauncher.java
+++ b/kettinglauncher/src/main/java/org/kettingpowered/ketting/KettingLauncher.java
@@ -4,6 +4,7 @@ import org.kettingpowered.ketting.common.betterui.BetterUI;
 import org.kettingpowered.ketting.internal.utils.JarTool;
 import org.kettingpowered.ketting.utils.FileUtils;
 import org.kettingpowered.ketting.utils.ServerInitHelper;
+import org.kettingpowered.ketting.utils.Unsafe;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -81,6 +82,7 @@ public class KettingLauncher {
         System.out.println("Launching Ketting...");
 
         fsHacks();
+        clearReservedIdentifiers();
 
         List<String> launchArgs = JarTool.readFileLinesFromJar("data/" + (System.getProperty("os.name").toLowerCase().contains("win") ? "win" : "unix") + "_args.txt");
         ServerInitHelper.init(launchArgs);
@@ -113,6 +115,14 @@ public class KettingLauncher {
             installedProvidersField.set(null, null);
         } catch (Exception e) {
             throw new RuntimeException("Could not set filesystem", e);
+        }
+    }
+
+    private static void clearReservedIdentifiers() {
+        try {
+            Unsafe.lookup().findStaticSetter(Class.forName("jdk.internal.module.Checks"), "RESERVED", Set.class).invoke(Set.of());
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -98,13 +98,18 @@ dependencyResolutionManagement {
 
             library('bungeecord-chat', 'net.md-5:bungeecord-chat:1.20-R0.1')
 
+            library('apache-commons2', 'commons-lang:commons-lang:2.6')
+            library('json-simple', 'com.googlecode.json-simple:json-simple:1.1.1')
+
             bundle('bukkitlibs', [
                     'yaml',
                     'maven-resolver-provider',
                     'maven-resolver-connector-basic',
                     'maven-resolver-transport-http',
                     'log4j-io',
-                    'bungeecord-chat'
+                    'bungeecord-chat',
+                    'apache-commons2',
+                    'json-simple'
             ])
             //Ketting libs
 


### PR DESCRIPTION
CraftBukkit bundles Commons Lang 2 and json-simple. Some plugins depend on these libraries.

Commons Lang 2 contains a package named `org.apache.commons.lang.enum`. Trying to load this package would normally result in an error as `enum` is a Java keyword. I've therefore added a method that disables this check.