### PR TITLE
Throw ClassNotFoundException when given an empty class name

### DIFF
--- a/src/main/java/org/kettingpowered/ketting/remapper/generated/KettingReflectionHandler.java
+++ b/src/main/java/org/kettingpowered/ketting/remapper/generated/KettingReflectionHandler.java
@@ -229,6 +229,8 @@ public class KettingReflectionHandler extends ClassLoader {
 
     // bukkit -> srg
     public static Class<?> redirectClassForName(String cl, boolean initialize, ClassLoader classLoader) throws ClassNotFoundException {
+        if (cl.isEmpty())
+            throw new ClassNotFoundException();
         try {
             String replace = remapper.mapType(cl.replace('.', '/')).replace('/', '.');
             return Class.forName(replace, initialize, classLoader);


### PR DESCRIPTION
Class.forName throws a ClassNotFoundException when given an empty String, but `remapper.mapType` throws a StringIndexOutOfBoundsException. This fixes compatibility with at least one very badly written plugin.