### PR TITLE
Remove 1.20.3 from bug report since we don't support it anymore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,6 @@ body:
       options:
         - 1.20.1
         - 1.20.2
-        - 1.20.3
         - 1.20.4
     validations:
       required: true


### PR DESCRIPTION
I mean, I don't see a 1.20.3 branch and in the discord server it is said by red that [1.20.3 is no longer supported](https://discord.com/channels/1172551819138965605/1223371369769730088/1225742244615557162) sooo