### PR TITLE
Remove 1.20.2 and 1.20.4 from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,6 +15,14 @@ body:
         - label: I have checked all items without reading.
         - label: I have provided proper reproduction steps
         - label: I have ticked all boxes
+  - type: dropdown
+    attributes:
+      label: What Minecraft Version is your Server on?
+      multiple: false
+      options:
+        - 1.20.1
+    validations:
+      required: true
   - type: input
     attributes:
       label: Full Ketting Version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,21 +9,12 @@ body:
       label: "Basic questions:"
       options:
         - label: I am actually using ketting, and not any other software (e.g. magma)
+        - label: I am not using an EOL version of ketting
         - label: I am using the latest Ketting version at the time of writing for the Minecraft version, that I am using
         - label: I have provided full server logs and not a crash-report
-        - label: I have checked all items without reading. 
+        - label: I have checked all items without reading.
         - label: I have provided proper reproduction steps
         - label: I have ticked all boxes
-  - type: dropdown
-    attributes:
-      label: What Minecraft Version is your Server on?
-      multiple: false
-      options:
-        - 1.20.1
-        - 1.20.2
-        - 1.20.4
-    validations:
-      required: true
   - type: input
     attributes:
       label: Full Ketting Version


### PR DESCRIPTION
I kept the version ask if/when ketting adds new versions, but since only 1.20.1 is supported(?) that is the only version that will be there.
Also adds a "I am not using an EOL version of ketting" checkbox to the issue template