### PR TITLE
chore: Print a warning instead of an error when WritableLevelData is null

### DIFF
--- a/src/main/java/org/kettingpowered/ketting/utils/DelegateWorldInfo.java
+++ b/src/main/java/org/kettingpowered/ketting/utils/DelegateWorldInfo.java
@@ -253,6 +253,8 @@ public class DelegateWorldInfo extends PrimaryLevelData {
         } else if (levelData instanceof ServerLevelData serverlevelData1) {
             org.kettingpowered.ketting.core.Ketting.LOGGER.warn("Could not wrap level data, this can cause some problems with bukkit", new UnsupportedOperationException());
             serverLevelData = serverlevelData1;
+        } else if (levelData == null) {
+            Ketting.LOGGER.warn("Could not get a ServerLevelData from a WritableLevelData because it is null.");
         } else {
             Ketting.LOGGER.error("Could not get a ServerLevelData from a WritableLevelData in Level constructor", new IllegalArgumentException("A WritableLevelData in the Level constructor wasn't a ServerLevelData"));
         }


### PR DESCRIPTION
Avoids print an error when the WritableLevelData is null

#454 

Idk how to fix it without changing code in the Create Ponder mod. The problem is this line:
https://github.com/Creators-of-Create/Ponder/blob/09e008a1406737d2a13beb7d36503a7e6d80258d/Common/src/main/java/net/createmod/catnip/levelWrappers/SchematicChunkSource.java#L111